### PR TITLE
updated graph components to use props

### DIFF
--- a/client/src/components/ChaosFlagChart.jsx
+++ b/client/src/components/ChaosFlagChart.jsx
@@ -4,9 +4,6 @@ import { Bar } from 'react-chartjs-2';
 class ChaosFlagChart extends Component {
   constructor(props){
     super(props);
-    this.state = {
-      chaosFlagChartData: props.chaosFlagChartData
-    }
   }
 
   static defaultProps = {
@@ -20,7 +17,7 @@ class ChaosFlagChart extends Component {
     return (
       <div className="chart">
         <Bar
-          data={this.state.chaosFlagChartData}
+          data={this.props.chaosFlagChartData}
           options={{
             title: {
               display: this.props.displayTitle,
@@ -30,6 +27,11 @@ class ChaosFlagChart extends Component {
             legend: {
               display: this.props.displayLegend,
               position: this.props.legendPosition
+            },
+            scales: {
+              xAxes: [{
+                barThickness: 7
+              }]
             }
           }}
         />

--- a/client/src/components/Graphs.jsx
+++ b/client/src/components/Graphs.jsx
@@ -1,75 +1,55 @@
-import React, { Component } from "react";
-import "./App.css";
-// import resultsData from './results';
-import SteadyStateChart from "./SteadyStateChart.jsx";
-import ChaosFlagChart from "./ChaosFlagChart.jsx";
-
-const chaosResults = resultsData.chaosResults;
-const agentData = resultsData.agentData;
-const chaosTimes = chaosResults.map(function(element) {
-  return element["timeOfResult"];  
-});
-const chaosData = chaosResults.map(function(element) {
-  return element["result"];
-});
-const agentTimes = agentData.map(function(element) {
-  return element["timeOfResponse"];
-});
-const chaosFlags = agentData.map(function(element) {
-  return element["chaosResponse"];
-});
-
+import React, { Component } from 'react';
+import SteadyStateChart from './SteadyStateChart.jsx';
+import ChaosFlagChart from './ChaosFlagChart.jsx';
 
 class Graphs extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       steadyStateChartData: {},
       chaosFlagChartData: {}
     };
   }
 
-  componentWillMount() {
-    this.getChartData();
-  }
+  // componentWillMount() {
+  //   this.getChartData();
+  // }
 
-  getChartData() {
-    // Ajax calls here, for example, pulling data from an API
-    this.setState({
-      steadyStateChartData: {
-        labels: chaosTimes,
-        datasets: [
-          {
-            label: "Latency",
-            data: chaosData,
-            fill: false
-          }
-        ]
-      },
-      chaosFlagChartData: {
-        labels: agentTimes,
-        datasets: [
-          {
-            label: "Chaos Instances",
-            data: chaosFlags,
-            backgroundColor: "red",
-            fill: false
-          }
-        ]
-      }
-    });
-  }
 
   render() {
+    const steadyStateChartConfig = {
+      labels: this.props.data.chaosTimes,
+      datasets: [
+        {
+          label: "Latency",
+          data: this.props.data.chaosData,
+          fill: false,
+          borderColor: "red",
+          backgroundColor: "blue"
+        }
+      ]
+    };
+    const chaosFlagChartConfig = {
+      labels: this.props.data.agentTimes,
+      datasets: [
+        {
+          label: "Chaos Instances",
+          data: this.props.data.agentFlags,
+          backgroundColor: "red",
+          fill: false
+        }
+      ]
+    }; 
+    console.log('props',  this.props);
     return (
       <div className="App">
         <h2>ChaosQoaLa Experiment Results</h2>
         <SteadyStateChart
-          steadyStateChartData={this.state.steadyStateChartData}
+          steadyStateChartData={steadyStateChartConfig}
           legendPosition="bottom"
         />
         <ChaosFlagChart 
-        chaosFlagChartData={this.state.chaosFlagChartData}
+        chaosFlagChartData={chaosFlagChartConfig}
         legendPosition="bottom"
         />
       </div>

--- a/client/src/components/SteadyStateChart.jsx
+++ b/client/src/components/SteadyStateChart.jsx
@@ -1,12 +1,9 @@
-import React, { Component } from "react";
-import { Line } from "react-chartjs-2";
+import React, { Component } from 'react';
+import { Line } from 'react-chartjs-2';
 
 class SteadyStateChart extends Component {
   constructor(props){
     super(props);
-    this.state = {
-      steadyStateChartData: props.steadyStateChartData
-    }
   }
 
   static defaultProps = {
@@ -20,11 +17,11 @@ class SteadyStateChart extends Component {
     return (
       <div className="chart">
         <Line
-          data={this.state.steadyStateChartData}
+          data={this.props.steadyStateChartData}
           options={{
             title: {
               display: this.props.displayTitle,
-              text: "Steady State Results",
+              text: "Steady State",
               fontSize: 25
             },
             legend: {


### PR DESCRIPTION
ChaosFlagChart.jsx and SteadyStateChart.jsx have been updated to use props, as opposed to state.
In addition, there was refactoring with the removal of the getChartData() method as the configuration for the steadyStateChart and the ChaosFlagChart are now declared as variables in the render method.